### PR TITLE
Update the NOTEBOOK Magic Input Name

### DIFF
--- a/phcnb/cli.py
+++ b/phcnb/cli.py
@@ -69,7 +69,7 @@ def create_input_from_param(parameter: Parameter):
 @click.argument('notebook', required=True)
 @click.argument('workflow_output', required=True, type=click.File('w'))
 def workflow(notebook, workflow_output, image, notebook_tool):
-    """ Convert NOTEBOOK into a workflow writton to WORKFLOW_OUTPUT.
+    """ Convert LIFEOMIC_NOTEBOOK into a workflow written to WORKFLOW_OUTPUT.
         Use '-' for WORKFLOW_OUTPUT to write the workflow to stdout.
     """
     parameters: Mapping[str, Parameter] = pm.inspect_notebook(notebook)
@@ -116,8 +116,8 @@ def workflow(notebook, workflow_output, image, notebook_tool):
             'type': 'string',
             'default': notebook_tool
         }
-        step_in['NOTEBOOK'] = 'notebook'
-        step_inputs['NOTEBOOK'] = {
+        step_in['LIFEOMIC_NOTEBOOK'] = 'notebook'
+        step_inputs['LIFEOMIC_NOTEBOOK'] = {
             'type': 'string'
         }
         arguments.append(f'/tmp/{os.path.basename(notebook)}')

--- a/phcnb/cli.py
+++ b/phcnb/cli.py
@@ -69,7 +69,7 @@ def create_input_from_param(parameter: Parameter):
 @click.argument('notebook', required=True)
 @click.argument('workflow_output', required=True, type=click.File('w'))
 def workflow(notebook, workflow_output, image, notebook_tool):
-    """ Convert LIFEOMIC_NOTEBOOK into a workflow written to WORKFLOW_OUTPUT.
+    """ Convert NOTEBOOK into a workflow written to WORKFLOW_OUTPUT.
         Use '-' for WORKFLOW_OUTPUT to write the workflow to stdout.
     """
     parameters: Mapping[str, Parameter] = pm.inspect_notebook(notebook)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phcnb"
-version = "0.1.2"
+version = "0.2.0"
 description = ""
 authors = [
     {name = "Anthony Roach", email = "anthony.roach@lifeomic.com"},


### PR DESCRIPTION
These changes update the magic `NOTEBOOK` input name to `LIFEOMIC_NOTEBOOK`. This is to follow the same semantic as our other magic inputs.